### PR TITLE
Temp Fix for Repeat Build Order

### DIFF
--- a/FAF_TUT_Theta_BO/FAF_TUT_Theta_BO_script.lua
+++ b/FAF_TUT_Theta_BO/FAF_TUT_Theta_BO_script.lua
@@ -179,6 +179,8 @@ function FirstFactoryBuilt()
 	IssueBuildFactory({ScenarioInfo.Factory_1}, 'uel0105', 2) -- T1 Engie
 	IssueBuildFactory({ScenarioInfo.Factory_1}, 'uel0201', 2) -- T1 Tank
 	IssueBuildFactory({ScenarioInfo.Factory_1}, 'uel0101', 1) -- T1 Scout
+	
+	loopFactoryBuildOrder(ScenarioInfo.Factory_1, 'uel0105')
 
 	-- Triggers for units
 	-- Engineer 1
@@ -466,6 +468,15 @@ function __EngineerBuildGroup(army, engineer, aiBrain, g)
             end
         end
     end
+end
+
+function loopFactoryBuildOrder(factory, unit)
+	while true do
+		WaitSeconds(0.1)
+		if factory:IsIdleState() then
+			IssueBuildFactory({factory}, unit, 3)
+		end
+	end
 end
 
 --------


### PR DESCRIPTION
I created a custom function that will run in an infinite loop, it will check if the requested Factory is Idle before it constructs these units. This is only a Temp Fix, it has been tested and it works. If a player requests a new build order, the loop will stop until the factory is idle again. Once it's finished constructing the new build queue and returns to the idle state, it will continue the repeated production.
